### PR TITLE
ci: configure trusted publishing for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,5 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: yarn semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -42,7 +42,7 @@
       }
     ],
     "@semantic-release/changelog",
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { "provenance": true }],
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
## Summary

- Remove NPM_TOKEN dependency
- Enable OIDC-based trusted publishing
- Add npm provenance support

## Test plan

- [ ] CI passes
- [ ] Release workflow uses trusted publishing after merge

Fixes #6