### PR TITLE
build: use node_modules linker for semantic-release

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
## Summary
- Switch Yarn from PnP to node_modules linker for semantic-release compatibility

## Problem
Release workflow failed with:
```
Cannot find module 'conventional-changelog-conventionalcommits'
```

Yarn PnP doesn't resolve modules correctly for semantic-release plugins.

## Solution
Created `.yarnrc.yml` with `nodeLinker: node-modules` to use traditional node_modules resolution.

Closes #13