### PR TITLE
ci: use sw-release-bot app token for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: tibdex/github-app-token@v2
         with:
-          app-id: ${{ vars.SW_RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.SW_RELEASE_BOT_PRIVATE_KEY }}
+          app_id: ${{ secrets.RELEASER_APP_ID }}
+          private_key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Use `tibdex/github-app-token@v2` to generate token from sw-release-bot app
- Use org-level secrets `RELEASER_APP_ID` and `RELEASER_APP_PRIVATE_KEY`
- Matches gitlab-mcp release workflow configuration

## Problem
Semantic-release fails to push CHANGELOG.md and package.json to protected main branch:
```
GH006: Protected branch update failed for refs/heads/main.
Changes must be made through a pull request.
```

## Solution
Use sw-release-bot app token which has bypass permissions for branch protection.

Fixes release workflow blocked by branch protection.