### PR TITLE
fix: replace vitepress inBrowser import with SSR-safe window check

### DIFF
--- a/src/vitepress/index.ts
+++ b/src/vitepress/index.ts
@@ -1,5 +1,4 @@
 import type { Theme } from "vitepress";
-import { inBrowser } from "vitepress";
 import { watch, nextTick } from "vue";
 import type { ConsentConfig } from "../core/types";
 import { createConsentPlugin, ConsentBanner, CONSENT_MANAGER_KEY } from "../vue/index";
@@ -45,7 +44,9 @@ export function enhanceWithConsent(theme: Theme, config: ConsentConfig): Theme {
       // Register global component
       ctx.app.component("ConsentBanner", ConsentBanner);
 
-      if (inBrowser) {
+      // SSR-safe browser check — avoid importing inBrowser from vitepress
+      // which is not available as a named export during SSR bundle compilation
+      if (typeof window !== "undefined") {
         // Initialize consent manager
         manager
           .init()


### PR DESCRIPTION
## Summary

- Replace `import { inBrowser } from "vitepress"` with `typeof window !== "undefined"` in the VitePress integration module
- The `inBrowser` named export is not available during VitePress SSR bundle compilation when imported from pre-built code in node_modules, causing build failure:
  ```
  The requested module 'vitepress' does not provide an export named 'inBrowser'
  ```

## Test plan

- [ ] `yarn build` succeeds
- [ ] `yarn lint` passes
- [ ] Built `dist/vitepress/index.js` does not contain `inBrowser`
- [ ] Consuming project (gitlab-mcp) `yarn docs:build` succeeds after updating to this version

Closes #27