### PR TITLE
fix(gtag): use Arguments object instead of Array in dataLayer.push

### DIFF
--- a/src/core/gtag.ts
+++ b/src/core/gtag.ts
@@ -16,8 +16,11 @@ export function initGtag(): void {
   window.dataLayer = window.dataLayer || [];
 
   if (typeof window.gtag !== "function") {
-    window.gtag = function gtag(...args: unknown[]) {
-      window.dataLayer.push(args);
+    // Must use `arguments` (not rest params) — gtag.js expects Arguments objects
+    // in the dataLayer, not plain Arrays. Using [...args] silently breaks collect.
+    window.gtag = function () {
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer.push(arguments);
     };
   }
 }


### PR DESCRIPTION
## Summary

- Fix critical bug where GA4 collect requests were never sent
- `dataLayer.push(args)` (Array) → `dataLayer.push(arguments)` (Arguments object)
- gtag.js silently ignores plain Arrays — expects Arguments objects

Fixes #35