### PR TITLE
ci(docs): trigger deploy on src/ changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'src/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Add `src/**` to docs deploy workflow path filter
- Docs site imports from `src/` directly — library code changes need redeploy

Fixes #37