### PR TITLE
docs: update README and fix docs site broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # @structured-world/vue-privacy
 
-GDPR-compliant cookie consent with **Google Consent Mode v2** support for Vue 3, Quasar, and VitePress.
+GDPR-compliant cookie consent with **Google Consent Mode v2** support for Vue 3, Quasar, VitePress, and plain HTML.
 
 [![npm version](https://img.shields.io/npm/v/@structured-world/vue-privacy.svg)](https://www.npmjs.com/package/@structured-world/vue-privacy)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+**[Documentation](https://privacy.sw.foundation)** · [GitHub](https://github.com/structured-world/vue-privacy) · [npm](https://www.npmjs.com/package/@structured-world/vue-privacy)
+
 ## Features
 
-- **Google Consent Mode v2** - Full support for `analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`
-- **EU Detection** - Auto-detect EU users via Cloudflare headers or IP API
-- **Framework Support** - Vue 3, Quasar, VitePress out of the box
-- **TypeScript** - Full type safety
-- **Lightweight** - No external dependencies for core functionality
-- **Customizable** - Fully configurable UI and behavior
-- **SSR Safe** - Works with server-side rendering
-- **Accessible** - ARIA-compliant banner component
+- **Google Consent Mode v2** — Full support for `analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`
+- **EU Detection** — Auto-detect EU users via Cloudflare headers, IP API, or timezone heuristics
+- **Consent Banner** — Customizable GDPR/CCPA banner with dark mode support
+- **Preference Center** — OneTrust-style modal with category toggles (necessary, analytics, marketing, functional)
+- **Script Blocking** — Block third-party scripts until consent is granted
+- **i18n** — 13 built-in locales (en, de, fr, es, it, pt, nl, pl, ru, uk, ja, zh, ko)
+- **Remote Storage** — Pluggable backend for cross-device consent sync
+- **Framework Support** — Vue 3, Quasar, VitePress, Nuxt 3
+- **UMD/CDN** — Use via `<script>` tag, no build tools needed
+- **TypeScript** — Full type safety
+- **Lightweight** — ~11kB gzip (UMD), no external dependencies
+- **SSR Safe** — Works with server-side rendering
+- **Accessible** — ARIA-compliant components with focus trap
 
 ## Installation
 
@@ -48,8 +55,8 @@ app.mount('#app');
 ```vue
 <template>
   <div id="app">
-    <!-- Your app content -->
     <ConsentBanner position="bottom" />
+    <ConsentPreferenceModal />
   </div>
 </template>
 ```
@@ -78,12 +85,29 @@ export default boot(consentBoot({
 }));
 ```
 
+### CDN / Script Tag
+
+```html
+<script src="https://unpkg.com/@structured-world/vue-privacy"></script>
+<script>
+  const manager = VuePrivacy.createConsentManager({
+    gaId: 'G-XXXXXXXXXX',
+    euDetection: 'auto',
+  });
+  manager.init();
+</script>
+```
+
 ## Configuration
 
 ```typescript
 interface ConsentConfig {
   // Google Analytics measurement ID
   gaId?: string;
+
+  // Locale for UI text (auto-detected if not set)
+  // Supported: en, de, fr, es, it, pt, nl, pl, ru, uk, ja, zh, ko
+  locale?: SupportedLocale;
 
   // Consent categories
   categories?: {
@@ -103,6 +127,20 @@ interface ConsentConfig {
     privacyLinkText?: string;
   };
 
+  // Preference center UI
+  preferenceCenter?: {
+    title?: string;
+    description?: string;
+    savePreferences?: string;
+    acceptAll?: string;
+    categories?: {
+      necessary?: { name?: string; description?: string };
+      analytics?: { name?: string; description?: string };
+      marketing?: { name?: string; description?: string };
+      functional?: { name?: string; description?: string };
+    };
+  };
+
   // Cookie settings
   cookie?: {
     name?: string;    // Default: 'consent_preferences'
@@ -110,6 +148,9 @@ interface ConsentConfig {
     domain?: string;
     path?: string;    // Default: '/'
   };
+
+  // Remote consent storage (pluggable backend)
+  storage?: ConsentStorage;
 
   // EU detection mode
   euDetection?: 'auto' | 'cloudflare' | 'api' | 'always' | 'never';
@@ -121,7 +162,95 @@ interface ConsentConfig {
   onConsentChange?: (consent: StoredConsent) => void;
   onBannerShow?: () => void;
   onBannerHide?: () => void;
+  onPreferenceCenterShow?: () => void;
+  onPreferenceCenterHide?: () => void;
 }
+```
+
+## Composables
+
+```vue
+<script setup>
+import { useConsent } from '@structured-world/vue-privacy/vue';
+
+const {
+  acceptAll,
+  rejectAll,
+  hasConsent,
+  resetConsent,
+  showPreferenceCenter,
+} = useConsent();
+</script>
+
+<template>
+  <button @click="showPreferenceCenter">Manage Cookies</button>
+</template>
+```
+
+## Script Blocking
+
+Block third-party scripts until consent is granted:
+
+```html
+<script type="text/plain" data-consent-category="analytics"
+        src="https://example.com/analytics.js"></script>
+
+<script type="text/plain" data-consent-category="marketing"
+        src="https://example.com/ads.js"></script>
+```
+
+Scripts are automatically unblocked when the matching category is accepted.
+
+## Remote Consent Storage
+
+Sync consent across devices with a pluggable backend:
+
+```typescript
+import { createConsentManager, createKVStorage } from '@structured-world/vue-privacy';
+
+// Built-in Cloudflare KV adapter
+const manager = createConsentManager({
+  gaId: 'G-XXXXXXXXXX',
+  storage: createKVStorage('/api/consent'),
+});
+
+// Or implement your own
+const manager = createConsentManager({
+  storage: {
+    get: (uid, version) => fetch(`/api/consent?id=${uid}`).then(r => r.json()),
+    set: (uid, consent) => fetch('/api/consent', {
+      method: 'POST',
+      body: JSON.stringify({ id: uid, ...consent }),
+    }).then(r => r.json()).then(d => d.id),
+  },
+});
+```
+
+## Core API (Framework-agnostic)
+
+```typescript
+import { createConsentManager } from '@structured-world/vue-privacy';
+
+const manager = createConsentManager({
+  gaId: 'G-XXXXXXXXXX',
+});
+
+await manager.init();
+
+// Programmatic consent
+await manager.acceptAll();
+await manager.rejectAll();
+await manager.savePreferences({ analytics: true, marketing: false });
+
+// Preference center
+manager.showPreferenceCenter();
+
+// Check state
+const consent = manager.getConsent();
+const isEU = manager.isEUUser();
+
+// Cleanup
+manager.destroy();
 ```
 
 ## EU Detection
@@ -137,69 +266,9 @@ Tries in order:
 2. IP API (ipapi.co)
 3. Timezone heuristics fallback
 
-### Cloudflare Setup
-
-Add a Transform Rule in Cloudflare Dashboard:
-
-**Rules > Transform Rules > Modify Request Header**
-
-- Header name: `X-Is-EU-Country`
-- Value: `ip.geoip.is_in_european_union`
-
-Or use a Worker:
-
-```typescript
-export default {
-  async fetch(request) {
-    const isEU = request.cf?.isEUCountry === true;
-    const response = await fetch(request);
-    const newResponse = new Response(response.body, response);
-    newResponse.headers.set('X-Is-EU-Country', isEU ? 'true' : 'false');
-    return newResponse;
-  }
-}
-```
-
-## Composables
-
-```vue
-<script setup>
-import { useConsent } from '@structured-world/vue-privacy/vue';
-
-const { acceptAll, rejectAll, hasConsent, resetConsent } = useConsent();
-</script>
-
-<template>
-  <button @click="resetConsent">Manage Cookies</button>
-</template>
-```
-
-## Core API (Framework-agnostic)
-
-```typescript
-import { createConsentManager } from '@structured-world/vue-privacy';
-
-const manager = createConsentManager({
-  gaId: 'G-XXXXXXXXXX',
-});
-
-// Initialize (shows banner for EU users)
-await manager.init();
-
-// Programmatic consent
-await manager.acceptAll();
-await manager.rejectAll();
-await manager.savePreferences({ analytics: true, marketing: false });
-
-// Check consent
-const consent = manager.getConsent();
-const hasConsent = manager.hasConsent();
-const isEU = manager.isEUUser();
-```
-
 ## Styling
 
-The banner uses CSS custom properties for theming:
+The banner and preference center use CSS custom properties:
 
 ```css
 :root {
@@ -217,41 +286,33 @@ The banner uses CSS custom properties for theming:
 
 Dark mode is automatically supported via `prefers-color-scheme`.
 
-## Status & Roadmap
-
-### Current (v1.0)
+## Current Features
 
 | Feature | Status |
 |---------|--------|
-| Consent banner component | Done |
-| Google Consent Mode v2 | Done |
-| GA4 integration | Done |
-| EU geo-detection | Done |
-| Vue 3 / VitePress / Quasar adapters | Done |
-| Local storage (cookie/localStorage) | Done |
-| Dark mode support | Done |
+| Consent banner component | ✅ |
+| Preference center modal | ✅ |
+| Google Consent Mode v2 | ✅ |
+| GA4 integration | ✅ |
+| EU geo-detection | ✅ |
+| Script blocking | ✅ |
+| i18n (13 locales) | ✅ |
+| Vue 3 / VitePress / Quasar / Nuxt 3 | ✅ |
+| UMD/CDN build | ✅ |
+| Remote consent storage | ✅ |
+| Dark mode support | ✅ |
 
-### Planned
+## Planned
 
 | Feature | Description |
 |---------|-------------|
-| Preference center modal | Full-featured modal with category toggles (OneTrust-style) |
-| Script blocking | Block 3rd-party scripts until consent given |
-| Multi-language (i18n) | Built-in translations for 20+ languages |
 | CCPA support | California Consumer Privacy Act compliance |
-| Server-side storage | Optional backend via [vue-privacy-worker](https://github.com/structured-world/vue-privacy-worker) |
-| Analytics dashboard | Opt-in rates, banner interactions (via privacy.structured.world) |
+| Analytics dashboard | Opt-in rates, banner interactions (via [privacy.structured.world](https://privacy.structured.world)) |
 
-### Related Projects
+## Related Projects
 
-- [vue-privacy-worker](https://github.com/structured-world/vue-privacy-worker) - Cloudflare Worker for server-side consent storage
+- [vue-privacy-worker](https://github.com/structured-world/vue-privacy-worker) — Cloudflare Worker for server-side consent storage
 
 ## License
 
-Apache 2.0 - see [LICENSE](LICENSE)
-
-## Links
-
-- [Documentation](https://privacy.sw.foundation)
-- [GitHub](https://github.com/structured-world/vue-privacy)
-- [npm](https://www.npmjs.com/package/@structured-world/vue-privacy)
+Apache 2.0 — see [LICENSE](LICENSE)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
             { text: "Preference Center", link: "/guide/preference-center" },
             { text: "Google Consent Mode v2", link: "/guide/consent-mode" },
             { text: "Script Blocking", link: "/guide/script-blocking" },
-            { text: "Geo Detection", link: "/guide/geo-detection" },
+            { text: "EU Detection", link: "/guide/eu-detection" },
             { text: "Customization", link: "/guide/customization" },
           ],
         },
@@ -118,7 +118,7 @@ export default defineConfig({
 
     footer: {
       message: "Released under the Apache 2.0 License. Powered by structured.world",
-      copyright: "Copyright 2025 Dmitry Prudnikov",
+      copyright: "Copyright 2025-2026 Dmitry Prudnikov",
     },
 
     editLink: {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import { h } from "vue";
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
 import { enhanceWithConsent, ConsentBanner } from "../../../src/vitepress/index";
+import { ConsentPreferenceModal } from "../../../src/vue/index";
 import { createKVStorage } from "../../../src/index";
 import "./style.css";
 import BugReportWidget from "./components/BugReportWidget.vue";
@@ -18,7 +19,12 @@ export default {
   ...consentTheme,
   Layout() {
     return h(consentTheme.Layout ?? DefaultTheme.Layout, null, {
-      "layout-bottom": () => [h(ConsentBanner), h(BugReportWidget), h(ConsentDebugPanel)],
+      "layout-bottom": () => [
+        h(ConsentBanner),
+        h(ConsentPreferenceModal),
+        h(BugReportWidget),
+        h(ConsentDebugPanel),
+      ],
     });
   },
 } satisfies Theme;

--- a/docs/guide/analytics.md
+++ b/docs/guide/analytics.md
@@ -1,0 +1,26 @@
+# Analytics
+
+::: warning Coming Soon
+Privacy-first analytics is planned as part of the [Privacy Platform](/guide/platform). This page will be updated when the feature launches.
+:::
+
+## Current Analytics Support
+
+vue-privacy integrates with **Google Analytics 4** (GA4) out of the box:
+
+- Automatic `gtag.js` loading with Consent Mode v2 defaults
+- SPA page view tracking (VitePress, Quasar, Vue Router)
+- Consent-aware tracking (no data sent without analytics consent)
+
+See [Google Consent Mode v2](/guide/consent-mode) for details.
+
+## Planned: Privacy-First Analytics
+
+The Privacy Platform will offer a built-in analytics alternative:
+
+- **No PII collection** — Page views and events without personal data
+- **Consent dashboard** — Opt-in rates, banner interaction metrics
+- **A/B testing** — Test banner variations to optimize consent rates
+- **ClickHouse-powered** — Fast aggregation for real-time dashboards
+
+These features will be available through the [privacy.structured.world](https://privacy.structured.world) dashboard.

--- a/docs/guide/consent-banner.md
+++ b/docs/guide/consent-banner.md
@@ -1,0 +1,115 @@
+# Consent Banner
+
+The consent banner is the primary UI component that asks users for cookie consent. It appears automatically for EU users and can be dismissed by accepting, rejecting, or customizing preferences.
+
+## Basic Usage
+
+### Vue 3
+
+```vue
+<template>
+  <ConsentBanner />
+</template>
+```
+
+The `ConsentBanner` component is registered globally when using `createConsentPlugin`. It automatically:
+
+- Shows for EU users who haven't given consent
+- Hides for non-EU users (consent is granted silently)
+- Hides after the user makes a choice
+- Persists the choice in a cookie for 365 days
+
+### VitePress
+
+The banner is included automatically with `enhanceWithConsent`:
+
+```typescript
+import DefaultTheme from 'vitepress/theme';
+import { enhanceWithConsent } from '@structured-world/vue-privacy/vitepress';
+
+export default enhanceWithConsent(DefaultTheme, {
+  gaId: 'G-XXXXXXXXXX',
+});
+```
+
+## Customizing Text
+
+Override banner text via configuration:
+
+```typescript
+createConsentPlugin({
+  banner: {
+    title: 'Cookie Settings',
+    message: 'We use cookies to enhance your browsing experience.',
+    acceptAll: 'Accept All Cookies',
+    rejectAll: 'Reject Non-Essential',
+    customize: 'Manage Preferences',
+    privacyLink: '/privacy-policy',
+    privacyLinkText: 'Read our Privacy Policy',
+  },
+});
+```
+
+### i18n
+
+Banner text is automatically translated based on the user's browser locale. 13 locales are built in: en, de, fr, es, it, pt, nl, pl, ru, uk, ja, zh, ko.
+
+To override the locale:
+
+```typescript
+createConsentPlugin({
+  locale: 'de', // Force German
+});
+```
+
+## Positioning
+
+The banner appears at the bottom of the viewport by default.
+
+```vue
+<ConsentBanner position="bottom" />
+```
+
+## Styling
+
+See [Customization](/guide/customization) for CSS custom properties and dark mode support.
+
+## Events
+
+The banner emits events when the user interacts:
+
+```vue
+<ConsentBanner
+  @accept="handleAccept"
+  @reject="handleReject"
+  @customize="handleCustomize"
+/>
+```
+
+## Callbacks
+
+```typescript
+createConsentPlugin({
+  onBannerShow: () => console.log('Banner shown'),
+  onBannerHide: () => console.log('Banner hidden'),
+  onConsentChange: (consent) => console.log('Consent:', consent),
+});
+```
+
+## Programmatic Control
+
+Use the `useConsent` composable to control the banner programmatically:
+
+```vue
+<script setup>
+import { useConsent } from '@structured-world/vue-privacy/vue';
+
+const { resetConsent } = useConsent();
+</script>
+
+<template>
+  <button @click="resetConsent">Manage Cookie Settings</button>
+</template>
+```
+
+Calling `resetConsent()` clears stored consent and shows the banner again.

--- a/docs/guide/platform.md
+++ b/docs/guide/platform.md
@@ -1,0 +1,40 @@
+# Privacy Platform
+
+::: warning Coming Soon
+The managed privacy platform at [privacy.structured.world](https://privacy.structured.world) is under development. This page will be updated when the platform launches.
+:::
+
+## What Is It?
+
+The Privacy Platform is an optional commercial companion to the open-source vue-privacy library. It provides:
+
+- **Multi-site management** — Manage consent across multiple domains from one dashboard
+- **Cookie scanner** — Auto-detect and categorize cookies on your site
+- **Consent analytics** — Track opt-in rates, banner interactions, and A/B test results
+- **Compliance reports** — Export consent records for audits
+- **Team access** — Invite team members with role-based permissions
+- **Custom branding** — Configure banner appearance per domain via dashboard
+
+## How It Connects
+
+The vue-privacy library works completely standalone with local cookie storage. The platform adds optional remote features via a `siteId` configuration:
+
+```typescript
+createConsentPlugin({
+  gaId: 'G-XXXXXXXXXX',
+  siteId: 'site_abc123', // From privacy.structured.world dashboard
+});
+```
+
+## Self-Hosted Alternative
+
+For teams that want remote consent storage without the managed platform, use the open-source [vue-privacy-worker](https://github.com/structured-world/vue-privacy-worker) with the `ConsentStorage` interface:
+
+```typescript
+import { createConsentManager, createKVStorage } from '@structured-world/vue-privacy';
+
+const manager = createConsentManager({
+  gaId: 'G-XXXXXXXXXX',
+  storage: createKVStorage('https://your-worker.your-domain.com/api/consent'),
+});
+```

--- a/docs/guide/preference-center.md
+++ b/docs/guide/preference-center.md
@@ -1,0 +1,134 @@
+# Preference Center
+
+The preference center is a modal dialog that lets users choose which cookie categories to allow. It opens when the user clicks "Customize" on the consent banner.
+
+## Basic Usage
+
+### Vue 3
+
+Add `ConsentPreferenceModal` to your app alongside the banner:
+
+```vue
+<template>
+  <ConsentBanner />
+  <ConsentPreferenceModal />
+</template>
+```
+
+Both components are registered globally by `createConsentPlugin`.
+
+### VitePress
+
+If using `enhanceWithConsent`, add the modal to your layout:
+
+```typescript
+import { h } from 'vue';
+import DefaultTheme from 'vitepress/theme';
+import { enhanceWithConsent, ConsentBanner } from '@structured-world/vue-privacy/vitepress';
+import { ConsentPreferenceModal } from '@structured-world/vue-privacy/vue';
+
+const consentTheme = enhanceWithConsent(DefaultTheme, {
+  gaId: 'G-XXXXXXXXXX',
+});
+
+export default {
+  ...consentTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'layout-bottom': () => [h(ConsentBanner), h(ConsentPreferenceModal)],
+    });
+  },
+};
+```
+
+## Categories
+
+The modal displays four cookie categories:
+
+| Category | Default | User can toggle |
+|----------|---------|-----------------|
+| **Necessary** | Always on | No (disabled) |
+| **Analytics** | Off | Yes |
+| **Marketing** | Off | Yes |
+| **Functional** | On | Yes |
+
+Each category shows a name and description, translated to the user's locale.
+
+## Opening Programmatically
+
+Use the `useConsent` composable:
+
+```vue
+<script setup>
+import { useConsent } from '@structured-world/vue-privacy/vue';
+
+const { showPreferenceCenter } = useConsent();
+</script>
+
+<template>
+  <button @click="showPreferenceCenter">Cookie Settings</button>
+</template>
+```
+
+Or via the core API:
+
+```typescript
+const manager = createConsentManager({ gaId: 'G-XXX' });
+await manager.init();
+manager.showPreferenceCenter();
+```
+
+## Customizing Text
+
+Override preference center text via config:
+
+```typescript
+createConsentPlugin({
+  preferenceCenter: {
+    title: 'Cookie Preferences',
+    description: 'Choose which cookies you want to allow.',
+    savePreferences: 'Save My Choices',
+    acceptAll: 'Accept Everything',
+    categories: {
+      analytics: {
+        name: 'Performance Cookies',
+        description: 'Help us understand how visitors use our site.',
+      },
+      marketing: {
+        name: 'Advertising Cookies',
+        description: 'Used to show relevant ads.',
+      },
+    },
+  },
+});
+```
+
+Text not explicitly overridden falls back to the built-in i18n translations for the active locale.
+
+## Accessibility
+
+The preference center includes:
+
+- `role="dialog"` and `aria-modal="true"`
+- `aria-labelledby` pointing to the modal title
+- `aria-label` on all toggle checkboxes
+- Focus trap (Tab cycles within the modal)
+- Focus moves to the modal container on open
+- Escape key closes the modal
+
+## Callbacks
+
+```typescript
+createConsentPlugin({
+  onPreferenceCenterShow: () => console.log('Preference center opened'),
+  onPreferenceCenterHide: () => console.log('Preference center closed'),
+});
+```
+
+## Styling
+
+The modal uses CSS-in-JS (auto-injected, SSR-safe). It supports:
+
+- Dark mode via `prefers-color-scheme`
+- Mobile-responsive layout (full-width on small screens)
+- CSS custom properties for theming (same as banner)

--- a/docs/guide/script-blocking.md
+++ b/docs/guide/script-blocking.md
@@ -1,0 +1,98 @@
+# Script Blocking
+
+Block third-party scripts from executing until the user grants consent for the matching category.
+
+## How It Works
+
+1. Mark scripts with `type="text/plain"` and a `data-consent-category` attribute
+2. The browser ignores `type="text/plain"` scripts (they don't execute)
+3. When the user grants consent, vue-privacy replaces them with executable copies
+
+## Usage
+
+### Marking Scripts
+
+Change your third-party script tags:
+
+```html
+<!-- Before: executes immediately -->
+<script src="https://example.com/analytics.js"></script>
+
+<!-- After: blocked until analytics consent -->
+<script type="text/plain" data-consent-category="analytics"
+        src="https://example.com/analytics.js"></script>
+```
+
+### Inline Scripts
+
+Inline scripts work the same way:
+
+```html
+<script type="text/plain" data-consent-category="marketing">
+  // This code runs only after marketing consent
+  fbq('init', '1234567890');
+  fbq('track', 'PageView');
+</script>
+```
+
+### Categories
+
+Use any of the built-in categories:
+
+| Category | Use for |
+|----------|---------|
+| `analytics` | Google Analytics, Hotjar, Mixpanel |
+| `marketing` | Facebook Pixel, Google Ads, TikTok |
+| `functional` | Chat widgets, preferences, A/B testing |
+
+## Automatic Integration
+
+When using `ConsentManager`, script blocking is enabled automatically:
+
+```typescript
+const manager = createConsentManager({ gaId: 'G-XXX' });
+await manager.init();
+// Script blocking is active — scripts unblock when consent changes
+```
+
+A `MutationObserver` watches for dynamically added blocked scripts and unblocks them if consent has already been granted.
+
+### Cleanup
+
+Call `destroy()` when unmounting your app to disconnect the observer:
+
+```typescript
+manager.destroy();
+```
+
+## Manual API (UMD/CDN)
+
+For non-Vue usage without `ConsentManager`:
+
+```html
+<script src="https://unpkg.com/@structured-world/vue-privacy"></script>
+<script>
+  // Manually unblock specific categories
+  VuePrivacy.unblockScriptsByCategory({
+    analytics: true,
+    marketing: false,
+    functional: true,
+  });
+</script>
+```
+
+## Preserving Script Type
+
+If the original script had a specific `type` (e.g., `module`), store it in `data-script-type`:
+
+```html
+<script type="text/plain" data-consent-category="analytics"
+        data-script-type="module"
+        src="https://example.com/modern-analytics.js"></script>
+```
+
+When unblocked, the script's `type` will be restored to `module`.
+
+## How Duplicate Execution Is Prevented
+
+Each script is marked with `data-consent-processed` after being unblocked. If `unblockScriptsByCategory` is called multiple times, processed scripts are skipped.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,56 @@
+# Privacy Policy
+
+**Last updated:** February 2026
+
+This site ([privacy.sw.foundation](https://privacy.sw.foundation)) is the documentation site for the open-source **@structured-world/vue-privacy** library, operated by [structured.world](https://structured.world).
+
+## What We Collect
+
+### Analytics (with consent)
+
+When you accept analytics cookies, we use **Google Analytics 4** (GA4) to understand how visitors use our documentation. This includes:
+
+- Pages visited and time spent
+- Referral source (how you found us)
+- Browser type, screen size, and operating system
+- Country (approximate, from IP)
+
+**We do not collect** personal information such as names, email addresses, or precise location.
+
+### Consent Preferences
+
+Your consent choice is stored:
+
+- **Locally** in a browser cookie (`consent_preferences`, 365 days)
+- **Remotely** in a Cloudflare KV store (anonymous UUID, no personal data)
+
+This allows us to remember your preference across visits.
+
+## Cookies Used
+
+| Cookie | Purpose | Duration | Category |
+|--------|---------|----------|----------|
+| `consent_preferences` | Stores your consent choices | 365 days | Necessary |
+| `consent_uid` | Anonymous ID for remote consent sync | 365 days | Necessary |
+| `_ga`, `_ga_*` | Google Analytics tracking | 2 years | Analytics |
+
+## Your Rights
+
+You can:
+
+- **Change preferences** at any time using the cookie settings button
+- **Reject all** non-essential cookies — the site works fully without them
+- **Clear cookies** in your browser settings
+
+## Third-Party Services
+
+- **Google Analytics** — [Google Privacy Policy](https://policies.google.com/privacy)
+- **Cloudflare** — [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/)
+
+## Contact
+
+For privacy questions: [GitHub Issues](https://github.com/structured-world/vue-privacy/issues)
+
+## Open Source
+
+This privacy policy is part of the vue-privacy documentation. The consent implementation itself is open source and [available on GitHub](https://github.com/structured-world/vue-privacy).


### PR DESCRIPTION
## Summary

- Rewrite README.md with all Phase 2 features (preference center, script blocking, i18n, UMD/CDN, remote consent storage)
- Create 5 missing guide pages that sidebar referenced but didn't exist (consent-banner, preference-center, script-blocking, platform, analytics)
- Create `docs/privacy.md` to fix `/privacy` 404 (default `privacyLink` in config)
- Fix sidebar `geo-detection` → `eu-detection` link to match actual file
- Add `ConsentPreferenceModal` to docs site theme so "Customize" button works
- Update copyright year to 2025-2026

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` — 92 tests pass
- [x] `yarn lint` — clean
- [ ] All 20 sidebar links resolve (no 404s)
- [ ] `/privacy` page renders on docs site
- [ ] "Customize" button opens preference center modal

Closes #66