### PR TITLE
fix: non-EU users get all consent granted without storing

### DIFF
--- a/src/__tests__/consent-manager.test.ts
+++ b/src/__tests__/consent-manager.test.ts
@@ -210,6 +210,28 @@ describe("ConsentManager banner deferred show (bannerPending)", () => {
     // Non-EU user: banner never shown, bannerPending stays false
     expect(showBanner).not.toHaveBeenCalled();
   });
+
+  it("does not store consent for non-EU user on init (default state)", async () => {
+    // Ensure no cookies exist before test
+    cookieStore = "";
+
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(false),
+      version: "1.0",
+    });
+
+    await manager.init();
+
+    // Non-EU user: consent is applied but NOT stored (it's the default state)
+    // No consent_preferences cookie should be set
+    expect(cookieStore).not.toContain("consent_preferences");
+
+    // But hasConsent() should return false (no stored consent)
+    expect(manager.hasConsent()).toBe(false);
+
+    // getConsent() should return null (nothing stored)
+    expect(manager.getConsent()).toBeNull();
+  });
 });
 
 describe("ConsentManager.getGeoResult()", () => {

--- a/src/core/consent-manager.ts
+++ b/src/core/consent-manager.ts
@@ -199,15 +199,16 @@ export class ConsentManager {
       }
       this.config.onBannerShow?.();
     } else {
-      // Non-EU user: grant consent silently
+      // Non-EU user: grant all consent silently (same as "Accept All").
+      // Don't store — this is the default state for unrestricted jurisdictions.
+      // Consent will only be stored if user explicitly changes preferences.
       const grantedCategories = {
         analytics: true,
-        marketing: this.config.categories?.marketing ?? false,
+        marketing: true,
         functional: true,
       };
 
       await this.applyConsent(grantedCategories);
-      this.saveConsentWithRemote(grantedCategories);
     }
   }
 


### PR DESCRIPTION
## Summary

- Grant all categories (including marketing) for non-EU users on init
- Don't store consent — it's the default state for unrestricted jurisdictions
- Consent only stored when user explicitly changes preferences via preference center

## Rationale

- Majority of world population is in unrestricted jurisdictions
- Storing "accept all" for every non-EU visitor is wasteful (unnecessary cookies/storage)
- Default assumption: all granted unless explicitly denied

## Test plan

- [x] Added test verifying no cookie is set for non-EU on init
- [x] All 120 tests pass
- [x] Build passes

Closes #70