### PR TITLE
chore: reduce npm package size from 589KB to 182KB

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "main": "./dist/vue-privacy.umd.cjs",
   "module": "./dist/index.js",
-  "unpkg": "./dist/vue-privacy.iife.js",
-  "jsdelivr": "./dist/vue-privacy.iife.js",
+  "unpkg": "./dist/vue-privacy.umd.cjs",
+  "jsdelivr": "./dist/vue-privacy.umd.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -72,7 +72,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "vite build && vite build --config vite.config.umd.ts && vue-tsc --emitDeclarationOnly",
+    "build": "vite build && vite build --config vite.config.umd.ts && vue-tsc --project tsconfig.build.json --emitDeclarationOnly",
     "dev": "vite build --watch",
     "typecheck": "vue-tsc --noEmit",
     "lint": "eslint src/",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "docs", "tests", "src/__tests__"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,10 @@ export default defineConfig({
     vue(),
     dts({
       include: ["src/**/*"],
+      exclude: ["src/__tests__/**"],
       outDir: "dist",
       rollupTypes: false,
-      tsconfigPath: "./tsconfig.json",
+      tsconfigPath: "./tsconfig.build.json",
     }),
   ],
   build: {
@@ -30,7 +31,7 @@ export default defineConfig({
         entryFileNames: "[name].js",
       },
     },
-    sourcemap: true,
-    minify: false,
+    sourcemap: false,
+    minify: "esbuild",
   },
 });

--- a/vite.config.umd.ts
+++ b/vite.config.umd.ts
@@ -2,11 +2,10 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 
 /**
- * Separate Vite config for UMD/IIFE build.
+ * Separate Vite config for UMD build.
  *
- * Produces framework-agnostic bundles for CDN usage:
+ * Produces framework-agnostic bundle for CDN usage:
  *   dist/vue-privacy.umd.cjs  — CommonJS/AMD/global
- *   dist/vue-privacy.iife.js  — self-executing script
  *
  * Run after the main ES build: `vite build --config vite.config.umd.ts`
  */
@@ -15,15 +14,12 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, "src/umd.ts"),
       name: "VuePrivacy",
-      formats: ["umd", "iife"],
-      fileName: (format) => {
-        if (format === "umd") return "vue-privacy.umd.cjs";
-        return `vue-privacy.${format}.js`;
-      },
+      formats: ["umd"],
+      fileName: () => "vue-privacy.umd.cjs",
     },
     outDir: "dist",
     emptyOutDir: false,
-    sourcemap: true,
+    sourcemap: false,
     minify: "esbuild",
   },
 });


### PR DESCRIPTION
## Summary

- Removed source maps from npm package (363KB saved)
- Enabled esbuild minification for ES build
- Removed redundant IIFE format, keep UMD only (31KB saved)
- Excluded test `.d.ts` files from package via `tsconfig.build.json`
- Updated `unpkg`/`jsdelivr` fields to use UMD bundle

## Results

| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Unpacked | 589 KB | 182 KB | **-69%** |
| Compressed | 158 KB | 51 KB | **-68%** |
| Files | 48+ | 39 | -9 |

Size is slightly above the target (<180KB) because actual minified JS code (~103KB) is larger than estimated (~70KB) in the issue.

## Test plan

- [x] `yarn lint` passes
- [x] `yarn test` passes (120 tests)
- [x] `yarn build` produces valid output
- [x] `npm pack --dry-run` shows 182KB unpacked
- [x] No test `.d.ts` files in package
- [x] UMD bundle works for CDN usage

Closes #78