### PR TITLE
feat: client-side consent analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ interface ConsentConfig {
   // Remote consent storage (pluggable backend)
   storage?: ConsentStorage;
 
+  // Consent analytics endpoint (fire-and-forget POST)
+  analyticsUrl?: string;
+
   // EU detection mode
   euDetection?: 'auto' | 'cloudflare' | 'api' | 'always' | 'never';
 
@@ -268,6 +271,25 @@ const manager = createConsentManager({
 });
 ```
 
+## Consent Analytics
+
+Track banner interactions to measure consent rates and optimize UX:
+
+```typescript
+const manager = createConsentManager({
+  gaId: 'G-XXXXXXXXXX',
+  storage: createKVStorage('/api/consent'),
+  analyticsUrl: '/api/analytics',  // Enable consent analytics
+});
+```
+
+Events tracked automatically:
+- `banner_shown` — When banner is displayed
+- `consent_given` — First consent decision (accept/reject)
+- `consent_updated` — Changes to existing preferences
+
+Includes `timeToDecision` (ms from banner to action) and `source` (banner vs preference_center). No PII is collected — only consent categories and timing. See the [Consent Analytics Guide](https://privacy.sw.foundation/guide/analytics#consent-analytics) for details.
+
 ## Core API (Framework-agnostic)
 
 ```typescript
@@ -343,6 +365,7 @@ Dark mode is automatically supported via `prefers-color-scheme`.
 | Vue 3 / VitePress / Quasar / Nuxt 3 | ✅ |
 | UMD/CDN build | ✅ |
 | Remote consent storage | ✅ |
+| Consent analytics (banner metrics) | ✅ |
 | Dark mode support | ✅ |
 
 ## Planned
@@ -350,7 +373,7 @@ Dark mode is automatically supported via `prefers-color-scheme`.
 | Feature | Description |
 |---------|-------------|
 | CCPA support | California Consumer Privacy Act compliance |
-| Analytics dashboard | Opt-in rates, banner interactions (via [privacy.structured.world](https://privacy.structured.world)) |
+| Advanced analytics dashboard | Aggregated opt-in rates, A/B testing for banners (via [privacy.structured.world](https://privacy.structured.world)) |
 
 ## Related Projects
 

--- a/docs/guide/analytics.md
+++ b/docs/guide/analytics.md
@@ -142,6 +142,99 @@ Recommended conversions:
 - `sign_up` — new registration
 - `generate_lead` — contact form submission
 
+## Consent Analytics
+
+Track how users interact with your consent banner. Events are sent to your analytics endpoint (fire-and-forget, no blocking).
+
+### Setup
+
+```typescript
+import { createConsentManager, createKVStorage } from '@structured-world/vue-privacy';
+
+const manager = createConsentManager({
+  gaId: 'G-XXXXXXXXXX',
+  storage: createKVStorage('/api/consent'),
+  analyticsUrl: '/api/analytics',  // Consent analytics endpoint
+});
+
+await manager.init();
+```
+
+### Events Tracked
+
+| Event | When | Data |
+|-------|------|------|
+| `banner_shown` | Banner displayed to user | `isEU`, `timestamp` |
+| `consent_given` | User accepts/rejects for first time | `categories`, `timeToDecision`, `source` |
+| `consent_updated` | User changes existing preferences | `categories`, `timeToDecision`, `source` |
+
+### Event Payload
+
+```typescript
+interface ConsentAnalyticsEvent {
+  event: 'banner_shown' | 'consent_given' | 'consent_updated';
+  timestamp: string;              // ISO 8601
+  categories?: {                  // Only for consent events
+    analytics: boolean;
+    marketing: boolean;
+    functional: boolean;
+  };
+  timeToDecision?: number;        // Milliseconds from banner to action
+  source?: 'banner' | 'preference_center';
+  isEU?: boolean;
+}
+```
+
+### Time-to-Decision Tracking
+
+Measures how long users take to make a consent decision:
+
+```typescript
+// timeToDecision = Date.now() - bannerShownAt
+// Typical values: 2000-10000ms for engaged users
+```
+
+This metric helps optimize your banner UX:
+- **< 2s**: Users clicking quickly (may not read)
+- **2-10s**: Engaged users making informed choice
+- **> 30s**: Banner may be confusing or intrusive
+
+### Source Tracking
+
+Tracks where consent actions originate:
+
+- `banner` — User clicked Accept/Reject on the main banner
+- `preference_center` — User saved preferences via the modal
+
+### Privacy Guarantees
+
+- **No PII sent** — Only consent categories and timing
+- **No cookies for analytics** — Uses fire-and-forget POST
+- **Silent failures** — Network errors don't affect consent flow
+- **EU status only** — No IP addresses or fingerprints
+
+### Backend Implementation
+
+Use [vue-privacy-worker](https://github.com/structured-world/vue-privacy-worker) for a ready-made Cloudflare Worker backend, or implement your own endpoint:
+
+```typescript
+// Your backend POST /api/analytics
+app.post('/api/analytics', (req, res) => {
+  const { event, timestamp, categories, timeToDecision, source, isEU } = req.body;
+
+  // Store in your analytics system
+  analytics.track(event, {
+    timestamp,
+    categories,
+    timeToDecision,
+    source,
+    isEU,
+  });
+
+  res.status(200).send('ok');
+});
+```
+
 ## Planned: Privacy-First Analytics
 
 The [Privacy Platform](/guide/platform) will offer a built-in analytics alternative:

--- a/src/__tests__/consent-manager.test.ts
+++ b/src/__tests__/consent-manager.test.ts
@@ -745,3 +745,278 @@ describe("ConsentManager ecommerce helpers", () => {
     });
   });
 });
+
+describe("ConsentManager consent analytics", () => {
+  let fetchCalls: Array<{ url: string; options: RequestInit; body: unknown }>;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    // Mock global fetch
+    global.fetch = vi.fn((url: string | URL | Request, options?: RequestInit) => {
+      const body = options?.body ? JSON.parse(options.body as string) : null;
+      fetchCalls.push({ url: url as string, options: options!, body });
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    }) as typeof fetch;
+  });
+
+  it("does not send analytics when analyticsUrl is not configured", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      version: "1.0",
+      // analyticsUrl not set
+    });
+
+    await manager.init();
+    await manager.acceptAll();
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("sends banner_shown event when banner is displayed", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    const showBanner = vi.fn();
+    manager.onShowBanner(showBanner);
+
+    await manager.init();
+
+    // Wait for async analytics
+    await vi.waitFor(() => {
+      const bannerShownCalls = fetchCalls.filter((c) => c.body?.event === "banner_shown");
+      expect(bannerShownCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "banner_shown")!;
+    expect(event.url).toBe("/api/analytics");
+    expect(event.body.isEU).toBe(true);
+    expect(event.body.timestamp).toBeDefined();
+  });
+
+  it("sends consent_given event on first acceptAll", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    // Register callback so bannerShownAt gets set
+    const showBanner = vi.fn();
+    manager.onShowBanner(showBanner);
+
+    await manager.init();
+    await manager.acceptAll();
+
+    await vi.waitFor(() => {
+      const consentCalls = fetchCalls.filter((c) => c.body?.event === "consent_given");
+      expect(consentCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "consent_given")!;
+    expect(event.body.categories).toEqual({
+      analytics: true,
+      marketing: true,
+      functional: true,
+    });
+    expect(event.body.source).toBe("banner");
+    expect(event.body.timeToDecision).toBeDefined();
+    expect(typeof event.body.timeToDecision).toBe("number");
+  });
+
+  it("sends consent_given event on first rejectAll", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    await manager.init();
+    await manager.rejectAll();
+
+    await vi.waitFor(() => {
+      const consentCalls = fetchCalls.filter((c) => c.body?.event === "consent_given");
+      expect(consentCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "consent_given")!;
+    expect(event.body.categories).toEqual({
+      analytics: false,
+      marketing: false,
+      functional: true,
+    });
+    expect(event.body.source).toBe("banner");
+  });
+
+  it("sends consent_given event on first savePreferences", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    await manager.init();
+    await manager.savePreferences({ analytics: true, marketing: false });
+
+    await vi.waitFor(() => {
+      const consentCalls = fetchCalls.filter((c) => c.body?.event === "consent_given");
+      expect(consentCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "consent_given")!;
+    expect(event.body.categories).toEqual({
+      analytics: true,
+      marketing: false,
+      functional: true,
+    });
+    expect(event.body.source).toBe("preference_center");
+  });
+
+  it("sends consent_updated event when user already had consent", async () => {
+    // Pre-set consent cookie (user already gave consent before)
+    cookieStore = `consent_preferences=${encodeURIComponent(
+      JSON.stringify({
+        categories: { analytics: true, marketing: false, functional: true },
+        timestamp: Date.now(),
+        version: "1.0",
+      })
+    )}`;
+
+    const manager = new ConsentManager({
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    await manager.init();
+
+    // User updates their preferences
+    await manager.savePreferences({ analytics: false, marketing: false });
+
+    await vi.waitFor(() => {
+      const consentCalls = fetchCalls.filter((c) => c.body?.event === "consent_updated");
+      expect(consentCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "consent_updated")!;
+    expect(event.body.categories).toEqual({
+      analytics: false,
+      marketing: false,
+      functional: true,
+    });
+  });
+
+  it("sends banner_shown event when onShowBanner is registered after bannerPending", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    // init() completes before onShowBanner is registered (sets bannerPending=true)
+    await manager.init();
+
+    // Now register callback
+    const showBanner = vi.fn();
+    manager.onShowBanner(showBanner);
+
+    await vi.waitFor(() => {
+      const bannerCalls = fetchCalls.filter((c) => c.body?.event === "banner_shown");
+      expect(bannerCalls.length).toBe(1);
+    });
+  });
+
+  it("sends banner_shown event on resetConsent", async () => {
+    // Pre-set consent cookie
+    cookieStore = `consent_preferences=${encodeURIComponent(
+      JSON.stringify({
+        categories: { analytics: true, marketing: false, functional: true },
+        timestamp: Date.now(),
+        version: "1.0",
+      })
+    )}`;
+
+    const manager = new ConsentManager({
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    await manager.init();
+
+    const showBanner = vi.fn();
+    manager.onShowBanner(showBanner);
+
+    // Reset consent should trigger banner_shown
+    manager.resetConsent();
+
+    await vi.waitFor(() => {
+      const bannerCalls = fetchCalls.filter((c) => c.body?.event === "banner_shown");
+      expect(bannerCalls.length).toBe(1);
+    });
+  });
+
+  it("silently fails when analytics endpoint returns error", async () => {
+    // Mock fetch to return error
+    global.fetch = vi.fn(() => Promise.reject(new Error("Network error"))) as typeof fetch;
+
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    // Should not throw
+    await manager.init();
+    await manager.acceptAll();
+
+    // Consent should still work (local storage)
+    expect(manager.hasConsent()).toBe(true);
+  });
+
+  it("tracks timeToDecision correctly", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    const showBanner = vi.fn();
+    manager.onShowBanner(showBanner);
+
+    await manager.init();
+
+    // Wait a bit before accepting
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await manager.acceptAll();
+
+    await vi.waitFor(() => {
+      const consentCalls = fetchCalls.filter((c) => c.body?.event === "consent_given");
+      expect(consentCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "consent_given")!;
+    // timeToDecision should be at least 50ms
+    expect(event.body.timeToDecision).toBeGreaterThanOrEqual(50);
+  });
+
+  it("uses correct source for acceptAll from preference_center", async () => {
+    const manager = new ConsentManager({
+      geoDetector: createMockGeoDetector(true),
+      analyticsUrl: "/api/analytics",
+      version: "1.0",
+    });
+
+    await manager.init();
+    await manager.acceptAll("preference_center");
+
+    await vi.waitFor(() => {
+      const consentCalls = fetchCalls.filter((c) => c.body?.event === "consent_given");
+      expect(consentCalls.length).toBe(1);
+    });
+
+    const event = fetchCalls.find((c) => c.body?.event === "consent_given")!;
+    expect(event.body.source).toBe("preference_center");
+  });
+});

--- a/src/core/consent-manager.ts
+++ b/src/core/consent-manager.ts
@@ -8,6 +8,9 @@ import type {
   GA4EcommerceParams,
   GA4PurchaseParams,
   GA4GenerateLeadParams,
+  ConsentAnalyticsEventType,
+  ConsentAnalyticsSource,
+  ConsentAnalyticsEvent,
 } from "./types";
 import { DEFAULT_CONFIG } from "./types";
 import { detectLocale } from "../i18n/index";
@@ -53,6 +56,10 @@ export class ConsentManager {
   private consentChangeListeners: Array<
     (categories: Omit<ConsentCategories, "necessary">) => void
   > = [];
+  /** Timestamp when banner was shown (for time-to-decision tracking) */
+  private bannerShownAt: number | null = null;
+  /** Tracks whether user has already given consent (for consent_given vs consent_updated) */
+  private hadPriorConsent = false;
 
   constructor(config: ConsentConfig = {}) {
     this.locale = config.locale ?? detectLocale();
@@ -78,7 +85,9 @@ export class ConsentManager {
     this.showBannerCallback = callback;
     if (this.bannerPending) {
       this.bannerPending = false;
+      this.bannerShownAt = Date.now();
       callback();
+      this.sendConsentAnalyticsEvent("banner_shown");
     }
   }
 
@@ -152,6 +161,7 @@ export class ConsentManager {
 
     // Fast-path: check consent_preferences cookie
     const stored = getStoredConsent(this.config);
+    this.hadPriorConsent = stored !== null;
 
     if (stored) {
       // Restore EU status and geo result from stored consent.
@@ -231,7 +241,9 @@ export class ConsentManager {
 
       // Show banner (or defer if component hasn't mounted yet)
       if (this.showBannerCallback) {
+        this.bannerShownAt = Date.now();
         this.showBannerCallback();
+        this.sendConsentAnalyticsEvent("banner_shown");
       } else {
         this.bannerPending = true;
       }
@@ -319,9 +331,44 @@ export class ConsentManager {
   }
 
   /**
+   * Send consent analytics event to the configured endpoint.
+   * Fire-and-forget: does not block, silently fails.
+   */
+  private sendConsentAnalyticsEvent(
+    event: ConsentAnalyticsEventType,
+    options?: {
+      categories?: Omit<ConsentCategories, "necessary">;
+      source?: ConsentAnalyticsSource;
+    }
+  ): void {
+    if (!this.config.analyticsUrl) return;
+
+    const timeToDecision =
+      this.bannerShownAt !== null ? Date.now() - this.bannerShownAt : undefined;
+
+    const payload: ConsentAnalyticsEvent = {
+      event,
+      timestamp: new Date().toISOString(),
+      ...(options?.categories && { categories: options.categories }),
+      ...(timeToDecision !== undefined && { timeToDecision }),
+      ...(options?.source && { source: options.source }),
+      ...(this.isEU !== null && { isEU: this.isEU }),
+    };
+
+    // Fire-and-forget POST request
+    fetch(this.config.analyticsUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).catch(() => {
+      // Silent fail — analytics is best-effort
+    });
+  }
+
+  /**
    * Accept all cookies
    */
-  async acceptAll(): Promise<void> {
+  async acceptAll(source: ConsentAnalyticsSource = "banner"): Promise<void> {
     const categories = {
       analytics: true,
       marketing: true,
@@ -330,6 +377,11 @@ export class ConsentManager {
 
     await this.applyConsent(categories);
     this.saveConsentWithRemote(categories);
+
+    // Send analytics event
+    const eventType = this.hadPriorConsent ? "consent_updated" : "consent_given";
+    this.sendConsentAnalyticsEvent(eventType, { categories, source });
+    this.hadPriorConsent = true;
 
     this.hideBannerCallback?.();
     this.hidePreferenceCenterCallback?.();
@@ -340,7 +392,7 @@ export class ConsentManager {
   /**
    * Reject all non-essential cookies
    */
-  async rejectAll(): Promise<void> {
+  async rejectAll(source: ConsentAnalyticsSource = "banner"): Promise<void> {
     const categories = {
       analytics: false,
       marketing: false,
@@ -349,6 +401,11 @@ export class ConsentManager {
 
     await this.applyConsent(categories);
     this.saveConsentWithRemote(categories);
+
+    // Send analytics event
+    const eventType = this.hadPriorConsent ? "consent_updated" : "consent_given";
+    this.sendConsentAnalyticsEvent(eventType, { categories, source });
+    this.hadPriorConsent = true;
 
     this.hideBannerCallback?.();
     this.hidePreferenceCenterCallback?.();
@@ -359,7 +416,10 @@ export class ConsentManager {
   /**
    * Save custom preferences
    */
-  async savePreferences(categories: Partial<Omit<ConsentCategories, "necessary">>): Promise<void> {
+  async savePreferences(
+    categories: Partial<Omit<ConsentCategories, "necessary">>,
+    source: ConsentAnalyticsSource = "preference_center"
+  ): Promise<void> {
     const finalCategories = {
       analytics: categories.analytics ?? false,
       marketing: categories.marketing ?? false,
@@ -368,6 +428,11 @@ export class ConsentManager {
 
     await this.applyConsent(finalCategories);
     this.saveConsentWithRemote(finalCategories);
+
+    // Send analytics event
+    const eventType = this.hadPriorConsent ? "consent_updated" : "consent_given";
+    this.sendConsentAnalyticsEvent(eventType, { categories: finalCategories, source });
+    this.hadPriorConsent = true;
 
     this.hideBannerCallback?.();
     this.hidePreferenceCenterCallback?.();
@@ -396,7 +461,12 @@ export class ConsentManager {
     clearConsent(this.config);
     clearConsentUid(this.config);
     this.userId = null;
-    this.showBannerCallback?.();
+    this.hadPriorConsent = false;
+    if (this.showBannerCallback) {
+      this.bannerShownAt = Date.now();
+      this.showBannerCallback();
+      this.sendConsentAnalyticsEvent("banner_shown");
+    }
     this.config.onBannerShow?.();
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,8 @@
 import type { SupportedLocale } from "../i18n/types";
 
+// Re-export for use in consent-manager
+export type { SupportedLocale };
+
 /**
  * Consent categories that can be managed
  */
@@ -158,8 +161,8 @@ export interface BannerConfig {
 
 /**
  * Supported locale codes for built-in translations
+ * (Re-exported from i18n/types at the top of this file)
  */
-export type { SupportedLocale } from "../i18n/types";
 
 /**
  * GA4 Item object for ecommerce events.
@@ -284,6 +287,39 @@ export interface GA4RouteMeta {
 }
 
 /**
+ * Consent analytics event types sent to the analytics endpoint.
+ * These events track user interactions with the consent banner.
+ */
+export type ConsentAnalyticsEventType =
+  | "banner_shown"
+  | "consent_given"
+  | "consent_updated"
+  | "banner_dismissed";
+
+/**
+ * Source of consent action (where the user made their choice).
+ */
+export type ConsentAnalyticsSource = "banner" | "preference_center";
+
+/**
+ * Payload sent to the analytics endpoint for consent events.
+ */
+export interface ConsentAnalyticsEvent {
+  /** Type of consent event */
+  event: ConsentAnalyticsEventType;
+  /** Timestamp when event occurred (ISO 8601) */
+  timestamp: string;
+  /** Categories that were accepted (only for consent_given/consent_updated) */
+  categories?: Omit<ConsentCategories, "necessary">;
+  /** Time in milliseconds from banner shown to user action */
+  timeToDecision?: number;
+  /** Where the consent action originated */
+  source?: ConsentAnalyticsSource;
+  /** Whether user is in EU */
+  isEU?: boolean;
+}
+
+/**
  * Main plugin configuration
  */
 export interface ConsentConfig {
@@ -347,6 +383,15 @@ export interface ConsentConfig {
    * or implement ConsentStorage interface for custom backends.
    */
   storage?: ConsentStorage;
+
+  /**
+   * URL for consent analytics endpoint.
+   * When set, consent events (banner_shown, consent_given, consent_updated)
+   * are sent to this URL via POST requests. Fire-and-forget, no blocking.
+   *
+   * @example '/api/analytics' or 'https://your-worker.workers.dev/api/analytics'
+   */
+  analyticsUrl?: string;
 
   /** Consent version (changing this resets consent for all users) */
   version?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,10 @@ export type {
   GA4GenerateLeadParams,
   GA4RouteEvent,
   GA4RouteMeta,
+  // Consent analytics types
+  ConsentAnalyticsEventType,
+  ConsentAnalyticsSource,
+  ConsentAnalyticsEvent,
 } from "./core/types";
 
 export type {


### PR DESCRIPTION
## Summary

- Add `analyticsUrl` config option to enable consent analytics
- Track banner interactions: `banner_shown`, `consent_given`, `consent_updated` events
- Measure `timeToDecision` (ms from banner to user action)
- Track `source` (banner vs preference_center)
- Fire-and-forget POST requests (no blocking, silent fail)

## Changes

- **src/core/types.ts**: Add `analyticsUrl` config option and new types (`ConsentAnalyticsEvent`, `ConsentAnalyticsSource`, `ConsentAnalyticsEventType`)
- **src/core/consent-manager.ts**: Add `sendConsentAnalyticsEvent()` method and integrate with `acceptAll`, `rejectAll`, `savePreferences`, `resetConsent`
- **src/index.ts**: Export new types
- **docs/guide/analytics.md**: Add "Consent Analytics" section with full documentation
- **README.md**: Add "Consent Analytics" section and update feature list

## Test plan

- [x] Unit tests for all analytics events (11 new tests added)
- [x] Tests for `banner_shown` on banner display and deferred registration
- [x] Tests for `consent_given` vs `consent_updated` distinction
- [x] Tests for `timeToDecision` tracking
- [x] Tests for silent failure on network errors
- [x] All 224 tests pass

Closes #74